### PR TITLE
Improved visualization pane and rendering

### DIFF
--- a/src/main/resources/templates/issuesgraph.html
+++ b/src/main/resources/templates/issuesgraph.html
@@ -130,7 +130,7 @@
     <div class="col-md-7">
         <div class="panel panel-default">
             <div class="panel-heading" id="visualGraph">Graph</div>
-            <div id="graph" style="width: 100%; height: auto"></div>
+            <div id="graph" style="position:relative; height: 50%;"></div>
         </div>
     </div>
 </div>
@@ -172,6 +172,7 @@
                         var event = issueEvent.name;
                         $eventList.append($("<li>" + event + "</li>"));
                     });
+                    render();
                 }, "json");
             return false;
         }
@@ -194,65 +195,73 @@
             return false;
         }
 
+        function render() {
+
+            d3.select("svg")
+                .remove();
+
+            var width = 500, height = 500;
+            var force = d3.layout.force()
+                .charge(-200).linkDistance(30).size([width, height]);
+
+            var svg = d3.select("#graph").append("svg")
+                .style("width", "100%").style("height", "100%")
+                .style("background-color", "white")
+                .attr("pointer-events", "all");
+
+            d3.json("/comicissues/buildgraph", function (error, graph) {
+                if (error) return;
+
+                force.nodes(graph.nodes).links(graph.links).start();
+                var link = svg.selectAll(".link")
+                    .data(graph.links).enter()
+                    .append("line").attr("class", "link");
+                var node = svg.selectAll(".node")
+                    .data(graph.nodes).enter()
+                    .append("circle")
+                    .attr("class", function (d) {
+                        return "node " + d.label
+                    })
+                    .attr("r", 10)
+                    .call(force.drag);
+
+                // html title attribute
+                node.append("svg:title")
+                    .text(function(d) {
+                        return "Type: " + d.label + "\nName: " + d.name;
+                    });
+                node.append("name")
+                    .text(function (d) {
+                        return d.name;
+                    });
+
+                // force feed algo ticks
+                force.on("tick", function () {
+                    link.attr("x1", function (d) {
+                        return d.source.x;
+                    })
+                        .attr("y1", function (d) {
+                            return d.source.y;
+                        })
+                        .attr("x2", function (d) {
+                            return d.target.x;
+                        })
+                        .attr("y2", function (d) {
+                            return d.target.y;
+                        });
+                    node.attr("cx", function (d) {
+                        return d.x;
+                    })
+                        .attr("cy", function (d) {
+                            return d.y;
+                        });
+                });
+            });
+        }
+
         $("#search").submit(search);
         search();
     })
-</script>
-
-<script type="text/javascript">
-    var width = 800, height = 800;
-
-    var force = d3.layout.force()
-        .charge(-200).linkDistance(30).size([width, height]);
-
-    var svg = d3.select("#graph").append("svg")
-        .attr("width", "100%").attr("height", "100%")
-        .attr("pointer-events", "all");
-
-    d3.json("/comicissues/buildgraph", function (error, graph) {
-        if (error) return;
-
-        force.nodes(graph.nodes).links(graph.links).start();
-        var link = svg.selectAll(".link")
-            .data(graph.links).enter()
-            .append("line").attr("class", "link");
-        var node = svg.selectAll(".node")
-            .data(graph.nodes).enter()
-            .append("circle")
-            .attr("class", function (d) {
-                return "node " + d.label
-            })
-            .attr("r", 10)
-            .call(force.drag);
-
-        // html title attribute
-        node.append("name")
-            .text(function (d) {
-                return d.name;
-            });
-
-        // force feed algo ticks
-        force.on("tick", function () {
-            link.attr("x1", function (d) {
-                return d.source.x;
-            })
-                .attr("y1", function (d) {
-                    return d.source.y;
-                })
-                .attr("x2", function (d) {
-                    return d.target.x;
-                })
-                .attr("y2", function (d) {
-                    return d.target.y;
-                });
-            node.attr("cx", function (d) {
-                return d.x;
-            })
-                .attr("cy", function (d) {
-                    return d.y;
-                });
-        });
-    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
Add a render function that loads the graph when user clicks on a comic issue in the list. Currently, visualization data does not update based on user click, but that is the eventual goal.